### PR TITLE
Add packwerk to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add packwerk to dependencies https://github.com/euglena1215/packwerk-yard/pull/6
+
 ## [0.1.0] - 2024-01-07
 
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in packwerk_yard.gemspec
 gemspec
 
-# TODO: Move to gemspec after merged https://github.com/Shopify/packwerk/pull/375
+# TODO: Remove this after merged https://github.com/Shopify/packwerk/pull/375
 gem "packwerk", git: "https://github.com/richardmarbach/packwerk", branch: "configurable_parser_interface"
 
 gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ PATH
   remote: .
   specs:
     packwerk_yard (0.1.0)
+      packwerk
       parser
       yard
 

--- a/packwerk_yard.gemspec
+++ b/packwerk_yard.gemspec
@@ -34,4 +34,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("parser")
   spec.add_dependency("yard")
+  # TODO: Set minimum version of packwerk after merged https://github.com/Shopify/packwerk/pull/375
+  spec.add_dependency("packwerk")
 end


### PR DESCRIPTION
In the Gemfile, packwerk was specified, but this does not show that it depends on the packwerk gem when installed as a gem.

Therefore, it is necessary to describe the dependencies of packwerk gem in gemspec as well. Note, however, that this gem depends on the implementation of the Pull Request, which is still under development, so it will not work with the latest version of packwerk.